### PR TITLE
Fix slide number increments in xaringan

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Imports:
     glue,
     purrr,
     rmarkdown
-RoxygenNote: 6.1.1
+RoxygenNote: 7.3.2
 Suggests: 
     testthat
 License: MIT + file LICENSE

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,6 +2,9 @@
 
 export("%>%")
 export(chunk_reveal)
+export(create_base_pipe_code)
 export(embed_flipbook)
+export(return_chunk_code)
 export(text_reveal)
 importFrom(magrittr,"%>%")
+importFrom(stringr,str_remove)

--- a/R/g_exported_functions.R
+++ b/R/g_exported_functions.R
@@ -40,6 +40,7 @@ knit_text_and_collapse <- function(text){
 #' @param color defines css parameter, defaults to "black"
 #' @param chunk_options input 'knitr' code chunk options as a string, default to empty string "", useful input might be "fig.height = 4, fig.width = 3"
 #' @param font_size_code this ain't working yet!
+#' @param count_first remove the 'count: false' from the first slide? (default is TRUE)
 #'
 #' @importFrom stringr str_remove
 #' @return a string object is returned will only work in 'knitr' context
@@ -72,7 +73,8 @@ chunk_reveal <- function(chunk_name = NULL,
                    float = "left",
                    chunk_options = "",
                    color = c("black", "black", "black"),
-                   font_size_code = "80%"
+                   font_size_code = "80%",
+                   count_first = TRUE
                    #,
                    # out.width = "70%",
                    # out.height = "70%"
@@ -154,7 +156,8 @@ chunk_reveal <- function(chunk_name = NULL,
                        #out.width = out.width
                        )
 
-  text = stringr::str_remove(text, '^count: false\n')
+  if(isTRUE(count_first))
+    text = stringr::str_remove(text, '^count: false\n')
 
   # if (chunk_reveal)
   paste(knitr::knit(text = text, quiet = F), collapse = "\n")

--- a/R/g_exported_functions.R
+++ b/R/g_exported_functions.R
@@ -154,8 +154,10 @@ chunk_reveal <- function(chunk_name = NULL,
                        )
 
   # if (chunk_reveal)
-  paste(knitr::knit(text = text, quiet = F), collapse = "\n")
-
+  text |>
+    stringr::str_replace('^count: false\n','count: true\n') |>
+    knitr::knit(text = _, quiet = FALSE) |>
+    paste(collapse = "\n")
 }
 
 

--- a/R/g_exported_functions.R
+++ b/R/g_exported_functions.R
@@ -154,10 +154,8 @@ chunk_reveal <- function(chunk_name = NULL,
                        )
 
   # if (chunk_reveal)
-  text |>
-    stringr::str_replace('^count: false\n','count: true\n') |>
-    knitr::knit(text = _, quiet = FALSE) |>
-    paste(collapse = "\n")
+  paste(knitr::knit(text = text, quiet = F), collapse = "\n")
+
 }
 
 

--- a/R/g_exported_functions.R
+++ b/R/g_exported_functions.R
@@ -41,6 +41,7 @@ knit_text_and_collapse <- function(text){
 #' @param chunk_options input 'knitr' code chunk options as a string, default to empty string "", useful input might be "fig.height = 4, fig.width = 3"
 #' @param font_size_code this ain't working yet!
 #'
+#' @importFrom stringr str_remove
 #' @return a string object is returned will only work in 'knitr' context
 #' @export
 #'
@@ -152,6 +153,8 @@ chunk_reveal <- function(chunk_name = NULL,
                        #out.height = out.height,
                        #out.width = out.width
                        )
+
+  text = stringr::str_remove(text, '^count: false\n')
 
   # if (chunk_reveal)
   paste(knitr::knit(text = text, quiet = F), collapse = "\n")

--- a/man/chunk_reveal.Rd
+++ b/man/chunk_reveal.Rd
@@ -6,16 +6,37 @@
 sequence to series of code chunks separated by slide breaks.
 Upon compiling you get step-by-step code walk-through.}
 \usage{
-chunk_reveal(chunk_name = NULL, break_type = "auto", left_assign = F,
-  left_assign_add = NULL, lang = "r", omit = "#OMIT",
-  code_seq = NULL, code_seq_lag = NULL, code_seq_lag2 = NULL,
-  code_seq_target = NULL, code_seq_start = NULL, func_seq = NULL,
-  num_breaks = NULL, display_type = c("code", "output"), title = "",
-  md = NULL, md2 = NULL, replacements = NULL, replace = NULL,
-  replacements2 = replacements, replace2 = replace,
-  replacements3 = replacements, replace3 = replace, widths = NULL,
-  float = "left", chunk_options = "", color = c("black", "black",
-  "black"), font_size_code = "80\%")
+chunk_reveal(
+  chunk_name = NULL,
+  break_type = "auto",
+  left_assign = F,
+  left_assign_add = NULL,
+  lang = "r",
+  omit = "#OMIT",
+  code_seq = NULL,
+  code_seq_lag = NULL,
+  code_seq_lag2 = NULL,
+  code_seq_target = NULL,
+  code_seq_start = NULL,
+  func_seq = NULL,
+  num_breaks = NULL,
+  display_type = c("code", "output"),
+  title = "",
+  md = NULL,
+  md2 = NULL,
+  replacements = NULL,
+  replace = NULL,
+  replacements2 = replacements,
+  replace2 = replace,
+  replacements3 = replacements,
+  replace3 = replace,
+  widths = NULL,
+  float = "left",
+  chunk_options = "",
+  color = c("black", "black", "black"),
+  font_size_code = "80\%",
+  count_first = TRUE
+)
 }
 \arguments{
 \item{chunk_name}{a character string referring to the name of the source chunk for the flipbooking}
@@ -73,6 +94,8 @@ chunk_reveal(chunk_name = NULL, break_type = "auto", left_assign = F,
 \item{color}{defines css parameter, defaults to "black"}
 
 \item{font_size_code}{this ain't working yet!}
+
+\item{count_first}{remove the 'count: false' from the first slide? (default is TRUE)}
 }
 \value{
 a string object is returned will only work in 'knitr' context


### PR DESCRIPTION
This change simply eliminates the first "count: false" in a sequence of generated flipbookr slides. This means that the first slide WILL increment properly, but the remaining ones will keep their "count: false" and so won't increment (as intended).